### PR TITLE
Fix bug in add_detailed_infos.py

### DIFF
--- a/place_explorer/utils/add_detailed_infos.py
+++ b/place_explorer/utils/add_detailed_infos.py
@@ -15,7 +15,7 @@ def get_info(place_id, outscraper_client, language="en"):
         url,
         sort="newest",
         language=language,
-        reviewsLimit=1,
+        review_limit=1,
     )
     # print(responses[0])
     try:


### PR DESCRIPTION
Renamed the keyword argument 'reviewsLimit' to 'review_limit' to avoid bugs due to recent updates from Outscraper.
